### PR TITLE
fix(briefing): serialize web_search calls to avoid Brave Free tier 429 (#8, #7)

### DIFF
--- a/skills/swain-briefing/SKILL.md
+++ b/skills/swain-briefing/SKILL.md
@@ -95,8 +95,11 @@ briefing.
    **Create cards one at a time** — research, create, then move to the next. Don't
    try to batch all research and all creation into one pass.
 
-   If `firecrawl` is slow or rate-limited, create cards from your own knowledge
-   (boat type tips, general boating content for the captain's region) rather than failing.
+   If `firecrawl` returns `FIRECRAWL_UNAVAILABLE` or any error, **do not silently skip** —
+   send a brief WhatsApp note: "Using backup research for some cards today." Then fall
+   back to `web_search` (sequential, 1 req/sec — see rate limit note below) or create
+   cards from your own knowledge (boat type tips, general boating content for the captain's
+   region) rather than failing silently.
 
 7. **Get captain context from Convex and memory**
    ```bash
@@ -300,6 +303,21 @@ top of the pull results next time you build a briefing.
 
 **Research before creating.** Use `web_search` and `web_fetch` for real data.
 Never fabricate content.
+
+**Rate limit note:** Brave Search (Free tier) allows 1 request/second. Always fire
+`web_search` calls **sequentially** — one at a time. Do not call `web_search` in
+parallel or in rapid succession. If you receive a 429 response, wait 2 seconds before
+retrying once. If the retry also fails, skip that search and use your own knowledge or
+`firecrawl search` as a fallback.
+
+```
+# Correct: sequential research
+web_search "redfish season Florida Gulf"      ← wait for result
+web_search "Marco Island marina amenities"    ← then fire next
+
+# Wrong: parallel research (triggers 429)
+web_search "topic A" | web_search "topic B"  ← don't do this
+```
 
 ## Briefing Item Types
 


### PR DESCRIPTION
## Problem

**Issue #8:** When firecrawl falls back to `web_search`, parallel calls hit Brave Search's Free tier rate limit (1 req/sec), causing 429 errors and thin briefing content.

**Issue #7:** When firecrawl returns `FIRECRAWL_UNAVAILABLE`, the briefing silently degrades — the captain gets no indication that some content is lower-quality.

## Root Cause

The briefing skill says "Research before creating" and "Create cards one at a time" but gives no explicit guidance on `web_search` call ordering. Under parallel execution, the LLM naturally fires multiple `web_search` calls at once, reliably hitting the Free tier 1 req/sec cap.

## Fix

Two targeted changes to `skills/swain-briefing/SKILL.md`:

**1. Serialization note** (in Research Tips section):
- Explicitly instructs: fire `web_search` calls one at a time
- 2-second wait on 429, one retry, then fall back
- Correct/wrong example patterns

**2. Improved firecrawl fallback** (in Step 6):
- `FIRECRAWL_UNAVAILABLE` → send WhatsApp note so captain knows
- Then fall back to sequential `web_search` or own knowledge — not silent degradation

## Testing

This is a skill instruction change (no code). Verified the diff doesn't affect:
- CLI command formats
- Convex data flow
- briefing structure or item types

The fix follows the existing pattern in the skill: "Create cards one at a time — don't batch" — this extends that serialization principle to research calls.